### PR TITLE
Pool freezes when connection is interrupted

### DIFF
--- a/asyncodbc/pool.py
+++ b/asyncodbc/pool.py
@@ -205,7 +205,7 @@ class Pool(asyncio.AbstractServer):
             self._terminated.remove(conn)
             return
         self._used.remove(conn)
-        if conn.connected:
+        if not conn.closed:
             if self._closing:
                 await conn.close()
             else:


### PR DESCRIPTION
`Connection.close` only sets `_conn = None`, it does not update `_connected`.  This causes a Pool to break when a Connection has been closed manually or if a connection error occurs causing the connection to be closed.