### PR TITLE
ci: remove ignore of main branch for push event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: ci
 on:
   push:
-    branches-ignore:
-      - main
     paths-ignore:
       - "docs/**"
       - "*.rst"


### PR DESCRIPTION
# Description

Do not ignore the main branch from push events; otherwise, the CI badge in the README will show an error.

<img width="434" height="344" alt="image" src="https://github.com/user-attachments/assets/32cd11db-8268-4a4b-b1d8-274eff7a84c3" />
